### PR TITLE
sftp fixes - signature of SFTP_open_dir, python 2.4 compatibility

### DIFF
--- a/src/sftp.c
+++ b/src/sftp.c
@@ -205,7 +205,11 @@ SFTP_write(SSH2_SFTPObj *self, PyObject *args)
 
 	CHECK_RETURN_CODE(ret, self->session)
 
+#if PY_VERSION_HEX < 0x02050000
+	return Py_BuildValue("i", ret);
+#else
 	return Py_BuildValue("n", ret);
+#endif
 }
 
 static PyObject *
@@ -221,7 +225,11 @@ SFTP_tell(SSH2_SFTPObj *self, PyObject *args)
 	ret = libssh2_sftp_tell(handle->sftphandle);
 	Py_END_ALLOW_THREADS
 
+#if PY_VERSION_HEX < 0x02050000
+	return Py_BuildValue("i", ret);
+#else
 	return Py_BuildValue("n", ret);
+#endif
 }
 
 static PyObject *


### PR DESCRIPTION
These are two small fixes, hopefully self-explanatory.
- The signature of SFTP_open_dir() was just wrong for a method
- reading and writing files failed under Python 2.4 failed because of the "type" argument passed to the Py_BuildValue call used to send the size of the file

I also had a problem with SFTP_handle_close() which I haven't fixed -- if you call it, then delete the handle, the handle gets closed a second time in SFTP_handle_dealloc(), and this sometimes leads to memory corruption and the application crashing. I'm dealing with this for now by not calling close() when I have a handle open.

Thanks for your consideration.
