### PR TITLE
libssh2_set/get_timeout

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -898,11 +898,13 @@ session_set_timeout(SSH2_SessionObj *self, PyObject *value, void *closure)
 	long timeout = PyLong_AsLong(value);
 
 	if (timeout == -1 && PyErr_Occurred()) {
-		PyErr_SetString(PyExc_TypeError, "must be integer");
+		/* older versions of python don't set TypeError */
+		if (PyErr_ExceptionMatches(PyExc_SystemError))
+			PyErr_SetString(PyExc_TypeError, "an integer is required");
 		return -1;
 	}
 
-	libssh2_session_set_timeout(self->session, PyLong_AsLong(value));
+	libssh2_session_set_timeout(self->session, timeout);
 	return 0;
 }
 #endif


### PR DESCRIPTION
These functions were added in 1.2.9 of libssh2. I've added them as an attribute of session, akin to blocking. This is done in a way that I hope preserves backward compatibility. I tested with 1.4.2 only.

Benefit of this call is if the channel dies but the session stays active, a ftp_read, say, can hang. Indeterminately. With a timeout set, it will time out.
